### PR TITLE
Tooltip theming

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/index.html
+++ b/index.html
@@ -1984,6 +1984,25 @@ of all or any part of the contents of this file is strictly prohibited.
             </div>
           </div>
         </div>
+        <div class="container">
+          <div class="row px-5">
+            <div class="col-md-12">
+              <h3 class="mt-5">Tooltips</h3>
+              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="Tooltip on left">
+                Tooltip on left
+              </button>
+              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
+                Tooltip on top
+              </button>
+              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">
+                Tooltip on bottom
+              </button>
+              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="Tooltip on right">
+                Tooltip on right
+              </button>
+            </div>
+          </div>
+        </div>
       </section>
       <section class="mb-5 pt-5" id="progress-bars">
         <div class="row bg-light py-4 mb-5">
@@ -2089,6 +2108,11 @@ of all or any part of the contents of this file is strictly prohibited.
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js" integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js" integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm" crossorigin="anonymous"></script>
+    <script>
+      $(function () {
+        $('[data-toggle="tooltip"]').tooltip();
+      });
+    </script>
 
   </body>
 </html>

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -767,20 +767,7 @@ $card-columns-margin:               $card-spacer-y !default;
 
 // Tooltips
 
-$tooltip-font-size:                 $font-size-sm !default;
-$tooltip-max-width:                 200px !default;
-$tooltip-color:                     $white !default;
-$tooltip-bg:                        $black !default;
-$tooltip-border-radius:             $border-radius !default;
-$tooltip-opacity:                   .9 !default;
-$tooltip-padding-y:                 .25rem !default;
-$tooltip-padding-x:                 .5rem !default;
-$tooltip-margin:                    0 !default;
-
-$tooltip-arrow-width:               .8rem !default;
-$tooltip-arrow-height:              .4rem !default;
-$tooltip-arrow-color:               $tooltip-bg !default;
-
+$tooltip-bg:                        $fluid-gray-3;
 
 // Popovers
 

--- a/src/components/_tooltip.scss
+++ b/src/components/_tooltip.scss
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011-2018, Hortonworks Inc. All rights reserved.
+ * Except as expressly permitted in a written agreement between you
+ * or your company and Hortonworks, Inc, any use, reproduction,
+ * modification, redistribution, sharing, lending or other exploitation
+ * of all or any part of the contents of this file is strictly prohibited.
+ */
+
+ .tooltip {
+    .tooltip-inner {
+      padding: 1rem; // if 1rem = 10px
+    }
+    &.tooltip-no-arrow {
+      .arrow {
+        display: none;
+      }
+    }
+    &.tooltip-light {
+      .tooltip-inner {
+        background-color: $white;
+        border: 1px solid darken($white, 14%);
+        box-shadow: 0 0 1rem 0 darken($white, 14%);
+        color: $fluid-gray-3;
+      }
+    }
+ }


### PR DESCRIPTION
Changes:

- change the background the tooltip (the other properties are the same as it is in BS)
- added light version of the tooltip
- added no-arrow extra css when we want to hide the arrow (eg.: charts)
- added html snippets and the JavaScript initialisation
- extra: added .editorconfig as the Bootstrap uses it