### PR TITLE
Improve some sizing calculations

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -324,7 +324,7 @@ $grid-gutter-width:           15px;
 $line-height-lg:              1.5 !default;
 $line-height-sm:              1.5 !default;
 
-$border-width:                px(1);
+$border-width:                1px;
 $border-color:                $gray-400;
 
 $border-radius:               px(2);
@@ -550,7 +550,7 @@ $input-plaintext-color:                 $body-color !default;
 $input-height-border:                   $input-border-width * 2 !default;
 
 $input-height-inner:                    ($font-size-base * $input-btn-line-height) + ($input-btn-padding-y * 2) !default;
-$input-height:                          $input-height-inner + $input-height-border; // let Sass do the math so we can use this value in other source files
+$input-height:                          $input-height-inner + px($input-height-border / 1px); // let Sass do the math so we can use this value in other source files
 
 $input-height-inner-sm:                 ($font-size-sm * $input-btn-line-height-sm) + ($input-btn-padding-y-sm * 2) !default;
 $input-height-sm:                       calc(#{$input-height-inner-sm} + #{$input-height-border}) !default;
@@ -728,7 +728,7 @@ $zindex-tooltip:                    1070 !default;
 
 // Navs
 
-$nav-link-margin:                   px($grid-gutter-width / 2px); //convert to rems
+$nav-link-margin:                   $grid-gutter-width / 2;
 $nav-link-padding-y:                $nav-link-margin;
 $nav-link-padding-x:                $nav-link-margin;
 $nav-link-disabled-color:           $gray-600 !default;
@@ -763,9 +763,10 @@ $navbar-nav-link-padding-x:           .5rem !default;
 
 $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
-$nav-link-height:                   ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
+$nav-link-height-formula:           #{$font-size-base} * #{$line-height-base} + #{$nav-link-padding-y} * 2;
+$nav-link-height:                   calc(#{$nav-link-height-formula});
 $navbar-brand-height:               px(60);
-$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y:            calc(((#{$nav-link-height-formula}) - #{$navbar-brand-height}) / 2);
 
 $navbar-brand-menu-spacing:         px(20);
 $navbar-brand-menu-item-size:       px(75);

--- a/scss/components/_navbar.scss
+++ b/scss/components/_navbar.scss
@@ -7,7 +7,7 @@
  */
 
 .navbar.navbar-header {
-  height: $navbar-brand-height + $border-width;
+  height: calc(#{$navbar-brand-height} + #{$border-width});
   min-width: $layout-min-width;
   background-color: $white;
   border-bottom: $border-width $body-bg solid;

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -21,8 +21,7 @@ nav.pagination {
   > div.fade {
     position: absolute;
     display: inherit;
-    right: calc((#{$pagination-icon-font-size} + #{$grid-gutter-width}) * 2 + #{$pagination-text-margin-right}); // let browser do the math so we can mix rem and px
-                                                                                                               //
+    right: calc((#{$pagination-icon-font-size} + #{$grid-gutter-width}) * 2 + #{$pagination-text-margin-right});
 
     .form-group {
       font-size: 0; // remove white space between inline elements


### PR DESCRIPTION
I changed the size of borders to be specified in absolute pixels, since we would not want borders to get thicker just because the font size changes. This also necessitated some changes to calculations that use the $border-width variable. I also changed some mixed-unit calculations to use the native calc() function so that we don't have to worry about converting units in SCSS.