### PR TITLE
Fix clipping of .navbar-primary dropdowns in Safari

### DIFF
--- a/scss/components/_navbar.scss
+++ b/scss/components/_navbar.scss
@@ -37,6 +37,11 @@
   overflow: hidden;
   @include transition($transition-collapse-all);
 
+  // test for Safari
+  @media (-webkit-animation) {
+    overflow: visible; // Safari
+  }
+
   * {
     flex-shrink: 0;
     align-items: normal;


### PR DESCRIPTION
Fixed an issue in Safari with dropdown menus getting clipped due to Safari's overflow bug. The fix was much simpler than I thought, no Javascript required!