### PR TITLE
Improve spacing of inline elements and text on buttons; replace some values with native units and variable references

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -224,7 +224,7 @@ $enable-print-styles:       true !default;
 // variables. Mostly focused on spacing.
 // You can add more entries to the $spacers map, should you need more variation.
 
-$spacer: px(15);
+$spacer: 15px;
 $spacers: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $spacers: map-merge(
@@ -238,6 +238,8 @@ $spacers: map-merge(
   ),
   $spacers
 );
+
+$inline-element-spacing: 4px; // Amount of space automatically inserted between inline elements; in most cases this is 4px.
 
 // This variable affects the `.h-*` and `.w-*` classes.
 $sizes: () !default;
@@ -447,7 +449,7 @@ $table-dark-color:            $body-bg !default;
 $table-striped-order:         odd !default;
 
 $table-caption-color:         $text;
-$table-caption-size:          px(20);
+$table-caption-size:          $font-size-lg;
 
 // Buttons + Forms
 //

--- a/scss/components/_breadcrumb.scss
+++ b/scss/components/_breadcrumb.scss
@@ -9,7 +9,7 @@
 .breadcrumb {
 
   .breadcrumb-item {
-    font-size: px(20);
+    font-size: $font-size-lg;
 
     &.active {
       color: gray("900");

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -8,7 +8,7 @@
 
 .btn {
   text-transform: uppercase;
-  line-height: px(22); // Correct vertical text centering
+  padding-bottom: .25rem; // Correct vertical text centering
 
   &.btn-primary {
     color: $white;
@@ -26,5 +26,21 @@
   &.btn-link {
     color: $link-color;
     border-color: transparent;
+  }
+
+  + .btn:not(.btn-link) {
+    margin-left: 10px - $inline-element-spacing;
+  }
+}
+
+.btn-group,
+.btn-group-vertical {
+
+  .btn,
+  .btn-group {
+
+    + .btn:not(.btn-link) {
+      margin-left: -$btn-border-width;
+    }
   }
 }

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2011-2018, Hortonworks Inc. All rights reserved.
+ * Except as expressly permitted in a written agreement between you
+ * or your company and Hortonworks, Inc, any use, reproduction,
+ * modification, redistribution, sharing, lending or other exploitation
+ * of all or any part of the contents of this file is strictly prohibited.
+ */
+
 .card {
 
   &:not(:last-child) {


### PR DESCRIPTION
- Added a variable to reference the default amount of space the browser adds between inline elements
- Improved the way text on buttons is vertically centered
- Changed some values to use native px or rem
- Replaced some hard-coded values with variable references