### PR TITLE
Improvements to close button

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -48,7 +48,7 @@ const addAlert = (message, options = {}) => {
     if (options.dismissible) {
       alert.classList.add('alert-dismissible');
       const temp = document.createElement('div');
-      temp.innerHTML = '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span class="icon icon-close" aria-hidden="true"></span></button>';
+      temp.innerHTML = '<button type="button" class="close" data-dismiss="alert" aria-label="Close"></button>';
       alert.appendChild(temp.firstChild);
     }
 

--- a/index.html
+++ b/index.html
@@ -1157,9 +1157,7 @@ of all or any part of the contents of this file is strictly prohibited.
                   <div class="alert-heading">Dismissible alert</div>
                   <div>Click the x to close me.</div>
                 </div>
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                  <span class="icon icon-close" aria-hidden="true"></span>
-                </button>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"></button>
               </div>
             </div>
           </div>

--- a/scss/components/_close.scss
+++ b/scss/components/_close.scss
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2011-2018, Hortonworks Inc. All rights reserved.
+ * Except as expressly permitted in a written agreement between you
+ * or your company and Hortonworks, Inc, any use, reproduction,
+ * modification, redistribution, sharing, lending or other exploitation
+ * of all or any part of the contents of this file is strictly prohibited.
+ */
+
+.close {
+  &:active,
+  &:focus {
+    outline: none;
+  }
+
+  &:before {
+    content: "*";
+    font-family: "fluidicons";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}


### PR DESCRIPTION
Improved `.close` class to automatically use the close icon from our `fluidicons` font.