### PR TITLE
Fix build problem that was causing fluid-bootstrap.min.css.map to be huge

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -133,7 +133,7 @@ gulp.task('transpile-sass', () =>
 
 gulp.task('minify-css', () =>
   gulp.src(css_src)
-    .pipe(sourcemaps.init())
+    .pipe(sourcemaps.init({ loadMaps: true }))
     .pipe(cleanCss())
     .pipe(rename({ suffix: '.min' }))
     .pipe(sourcemaps.write('./'))


### PR DESCRIPTION
I noticed that `fluid-bootstrap.min.css.map` was around 38mb for some reason. This fixes the problem.