### PR TITLE
Separate $status-icons from $theme-icons.

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -14,6 +14,10 @@
   @return map-get($theme-icons, $key);
 }
 
+@function status-icon($key) {
+  @return map-get($status-icons, $key);
+}
+
 @function px($pixels, $basis: 1rem) {
   @return (($pixels * 1px) / $root-font-size) * $basis;
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -166,6 +166,7 @@ $icon-danger:           "\2d"; /* '-' */
 $icon-sort-up:          "\2f"; /* '/' */
 $icon-menu:             "\3a"; /* ':' */
 $icon-previous:         "\3c"; /* '&lt;' */
+$icon-check:            "\3d"; /* '=' */
 $icon-next:             "\3e"; /* '&gt;' */
 $icon-help:             "\3f"; /* '?' */
 $icon-sort-down:        "\5c"; /* '\' */
@@ -176,11 +177,13 @@ $icon-unsorted:         "\7c"; /* '|' */
 $icon-navbar-expand:    "\7d"; /* '}' */
 $icon-filter:           "\7e"; /* '~' */
 
+
 $theme-icons: ();
 // stylelint-disable-next-line scss/dollar-variable-default
 $theme-icons: map-merge(
   (
     "apps":            $icon-apps,
+    "check":           $icon-check,
     "close":           $icon-close,
     "collapse":        $icon-collapse,
     "danger":          $icon-danger,
@@ -201,6 +204,18 @@ $theme-icons: map-merge(
     "warning":         $icon-warning,
   ),
   $theme-icons
+);
+
+$status-icons: ();
+// stylelint-disable-next-line scss/dollar-variable-default
+$status-icons: map-merge(
+  (
+    "danger":          $icon-danger,
+    "info":            $icon-info,
+    "success":         $icon-success,
+    "warning":         $icon-warning,
+  ),
+  $status-icons
 );
 
 

--- a/scss/components/_alert.scss
+++ b/scss/components/_alert.scss
@@ -67,7 +67,7 @@
   }
 }
 
-@each $icon, $value in $theme-icons {
+@each $icon, $value in $status-icons {
   .alert-#{$icon} {
     &:before {
       content: $value;

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -36,13 +36,13 @@ label {
 }
 
 .valid-feedback:before {
-  content: theme-icon("success");
-  color: theme-color("success");
+  content: status-icon("success");
+  color: status-color("success");
 }
 
 .invalid-feedback:before {
-  content: theme-icon("danger");
-  color: theme-color("danger");
+  content: status-icon("danger");
+  color: status-color("danger");
 }
 
 // Make all <select> dropdowns themed


### PR DESCRIPTION
I created a new $status-icons map to separate the status icons from the other icons in the $theme-icons map. This was needed to prevent generation of alert variants for the non-status icons.

Also, added the new "check" icon to the $theme-icons map.