### PR TITLE
Disabled linter properties-order rule.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,5 +1,8 @@
 {
   "extends": [
     "stylelint-config-twbs-bootstrap/scss"
-  ]
+  ],
+  "rules": {
+    "order/properties-order": null
+  }
 }


### PR DESCRIPTION
This should not be enables since it makes no difference in what order the CSS properties are written inside a selector. If anything those should be alphabetically ordered  so that duplicates can be avoided.